### PR TITLE
Bump `tf_label` version to `0.2.0`. Add `attributes` and `tags`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # Module directory
 .terraform/
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Include this repository as a module in your existing terraform code:
 
 ```
 module "efs" {
-  source    = "git::https://github.com/cloudposse/tf_efs.git?ref=tags/0.1.0"
-  namespace       = "general"
-  name            = "nfs"
-  stage           = "prod"
+  source     = "git::https://github.com/cloudposse/tf_efs.git?ref=tags/0.2.0"
+  namespace  = "global"
+  name       = "app"
+  stage      = "prod"
+  attributes = "efs"
 
   aws_region         = "${var.aws_region}"
   vpc_id             = "${var.vpc_id}"
@@ -25,22 +26,25 @@ module "efs" {
 
 ## Input
 
-|  Name              |  Default     |  Decription            |
-|:------------------:|:------------:|:----------------------:|
-| namespace          | global       | Namespace              |
-| stage              | default      | Stage                  |
-| name               | redis        | Name                   |
-| security_groups    | []           | AWS security group ids |
-| aws_region         | __REQUIRED__ | AWS region id          |
-| vpc_id             | __REQUIRED__ | AWS VPC id             |
-| subnets            | []           | AWS subnet ids         |
-| availability_zones | []           | Availability zone ids  |
-| zone_id            | __REQUIRED__ | Route53 dns zone id    |
+|  Name              |    Default     |                          Decription                              |
+|:------------------:|:--------------:|:----------------------------------------------------------------:|
+| namespace          | `global`       | Namespace                                                        |
+| stage              | `default`      | Stage                                                            |
+| name               | `app`          | Name                                                             |
+| security_groups    | `[]`           | AWS security group ids to allow to connect to the EFS            |
+| aws_region         | __REQUIRED__   | AWS region id                                                    |
+| vpc_id             | __REQUIRED__   | AWS VPC id                                                       |
+| subnets            | `[]`           | AWS subnet ids                                                   |
+| availability_zones | `[]`           | Availability zone ids                                            |
+| zone_id            | __REQUIRED__   | Route53 dns zone id                                              |
+| `attributes`       | `[]`           | Additional attributes (e.g. `policy` or `role`)                  |
+| `tags`             | `{}`           | Additional tags  (e.g. `map("BusinessUnit","XYZ")`               |
+| `delimiter`        | `-`            | Delimiter to be used between `name`, `namespace`, `stage`, etc.  |
 
 
 ## Output
 
-| Name | Decription |
-|:----:|:----------:|
-| id   | EFS id     |
-| host | EFS host   |
+| Name |        Decription               |
+|:----:|:-------------------------------:|
+| id   | EFS id                          |
+| host | Assigned DNS-record for the EFS |

--- a/README.md
+++ b/README.md
@@ -26,25 +26,25 @@ module "efs" {
 
 ## Input
 
-|  Name              |    Default     |                          Decription                              |
-|:------------------:|:--------------:|:----------------------------------------------------------------:|
-| namespace          | `global`       | Namespace                                                        |
-| stage              | `default`      | Stage                                                            |
-| name               | `app`          | Name                                                             |
+|  Name              |    Default     |                          Description                             |
+|:-------------------|:--------------:|:-----------------------------------------------------------------|
+| namespace          | `global`       | Namespace (_e.g._ `cp` or `cloudposse`)                          |
+| stage              | `default`      | Stage (_e.g._ `prod`, `dev`, `staging`)                          |
+| name               | `app`          | Name (_e.g._ `app` or `wordpress`)                               |
 | security_groups    | `[]`           | AWS security group ids to allow to connect to the EFS            |
 | aws_region         | __REQUIRED__   | AWS region id                                                    |
 | vpc_id             | __REQUIRED__   | AWS VPC id                                                       |
 | subnets            | `[]`           | AWS subnet ids                                                   |
 | availability_zones | `[]`           | Availability zone ids                                            |
 | zone_id            | __REQUIRED__   | Route53 dns zone id                                              |
-| `attributes`       | `[]`           | Additional attributes (e.g. `policy` or `role`)                  |
-| `tags`             | `{}`           | Additional tags  (e.g. `map("BusinessUnit","XYZ")`               |
-| `delimiter`        | `-`            | Delimiter to be used between `name`, `namespace`, `stage`, etc.  |
+| attributes         | `[]`           | Additional attributes (e.g. `policy` or `role`)                  |
+| tags               | `{}`           | Additional tags  (e.g. `map("BusinessUnit","XYZ")`               |
+| delimiter          | `-`            | Delimiter to be used between `name`, `namespace`, `stage`, etc.  |
 
 
 ## Output
 
-| Name |        Decription               |
-|:----:|:-------------------------------:|
+| Name |        Description              |
+|:-----|:--------------------------------|
 | id   | EFS id                          |
 | host | Assigned DNS-record for the EFS |

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,13 @@
 # Define composite variables for resources
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  source     = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  stage      = "${var.stage}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
-
 
 resource "aws_efs_file_system" "default" {
   tags {

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "stage" {
 }
 
 variable "name" {
-  default = "efs"
+  default = "app"
 }
 
 variable "security_groups" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,18 @@ variable "availability_zones" {
 }
 
 variable "zone_id" {}
+
+variable "delimiter" {
+  type    = "string"
+  default = "-"
+}
+
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}


### PR DESCRIPTION
## What

* Propagate `attributes` and `tags` from `variables.tf` to the internal `label` module


## Why

* The internal `tf_label`  `attributes` and `tags` should be accessible from outside of the module
